### PR TITLE
Add nose arguments to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
 verbosity=1
+with-spec = True
+spec-color = True
+with-coverage = True
+cover-erase = True
+cover-package = service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Enable color and coverage flags so that running nosetests automatically includes -vv --with-spec --spec-color --with-coverage --cover-erase --cover-package=service.